### PR TITLE
Make Thread ID a number

### DIFF
--- a/filter-50-errorlog.conf
+++ b/filter-50-errorlog.conf
@@ -1,6 +1,6 @@
 filter {
   grok {
-    match => ["message","%{TIMESTAMP_ISO8601:timestamp} %{NUMBER:[process][thread][id]} \[%{LOGLEVEL:[log][level]}\] %{GREEDYDATA:message}"]
+    match => ["message","%{TIMESTAMP_ISO8601:timestamp} %{NUMBER:[process][thread][id]:int} \[%{LOGLEVEL:[log][level]}\] %{GREEDYDATA:message}"]
     id => mysql_errorlog
     tag_on_failure => ["_grokparsefailure","mysql_errorlog_failed"]
     overwrite => "message"


### PR DESCRIPTION
Thread ID must be am integer (more exactly: `long`) according to ECS. So we should typecast it wherever possible.