### PR TITLE
Fix date parseing failure

### DIFF
--- a/filter-50-errorlog.conf
+++ b/filter-50-errorlog.conf
@@ -6,7 +6,7 @@ filter {
     overwrite => "message"
   }
   date {
-    match => ["timestamp","ISO8601"]
+    match => ["timestamp","YYYY-MM-dd HH:mm:ss", "ISO8601"]
     id => mysql_errorlog_date
   }
   mutate {


### PR DESCRIPTION
The date matches grok pattern `ISO8601` but isn't actually ISO8601. So we need to have a custom pattern.