### PR TITLE
Fix time pattern for MariaDB logs

### DIFF
--- a/filter-50-errorlog.conf
+++ b/filter-50-errorlog.conf
@@ -1,12 +1,12 @@
 filter {
   grok {
-    match => ["message","%{TIMESTAMP_ISO8601:timestamp} %{NUMBER:[process][thread][id]:int} \[%{LOGLEVEL:[log][level]}\] %{GREEDYDATA:message}"]
+    match => ["message","%{DATA:timestamp} %{NUMBER:[process][thread][id]:int} \[%{LOGLEVEL:[log][level]}\] %{GREEDYDATA:message}"]
     id => mysql_errorlog
     tag_on_failure => ["_grokparsefailure","mysql_errorlog_failed"]
     overwrite => "message"
   }
   date {
-    match => ["timestamp","YYYY-MM-dd HH:mm:ss", "ISO8601"]
+    match => ["timestamp","YYYY-MM-dd HH:mm:ss", "YYYY-MM-dd  H:mm:ss", "ISO8601"]
     id => mysql_errorlog_date
   }
   mutate {


### PR DESCRIPTION
MariaDB introduces a new logformat with where single digit hours are written without 0 padding but with an extra whitespace in front.