### PR TITLE
Parse new names for severities

### DIFF
--- a/filter-50-errorlog.conf
+++ b/filter-50-errorlog.conf
@@ -1,6 +1,6 @@
 filter {
   grok {
-    match => ["message","%{DATA:timestamp} %{NUMBER:[process][thread][id]:int} \[%{LOGLEVEL:[log][level]}\] %{GREEDYDATA:message}"]
+    match => ["message","%{DATA:timestamp} %{NUMBER:[process][thread][id]:int} \[%{WORD:[log][level]}\] %{GREEDYDATA:message}"]
     id => mysql_errorlog
     tag_on_failure => ["_grokparsefailure","mysql_errorlog_failed"]
     overwrite => "message"


### PR DESCRIPTION
Some severities don't match the `LOGLEVEL` pattern.